### PR TITLE
Moved the splitting of the spritesheets into BufferedImageArrays into the BufferedImageLoader-class

### DIFF
--- a/src/com/espen/src/Actor.java
+++ b/src/com/espen/src/Actor.java
@@ -18,25 +18,18 @@ public abstract class Actor extends Entity {
 	/**
 	 * Constructor
 	 * 
-	 * @param image
-	 *            Spritesheet for this character
+	 * @param sprite
+	 *            Spritesheet for this Entity
 	 * @param game
 	 *            A reference to a game-object to get access to the other
 	 *            subsystems
-	 * @param cols
-	 *            number of columns the animation takes in the spritesheet
-	 * @param rows
-	 *            number of rows the animation takes in the spritesheet
-	 * @param animationSpeed
-	 *            how many ticks between the animation jumps to the next
-	 *            subimage
 	 * @param x
 	 *            x-coordinate of desired spawn-point
 	 * @param y
 	 *            y-coordinate of desired spawn-point
 	 */
-	public Actor(BufferedImage image, Game game, int cols, int rows, int animationSpeed, double x, double y) {
-		super(image, game, cols, rows, animationSpeed, x, y);
+	public Actor(BufferedImage[] sprite, Game game, double x, double y) {
+		super(sprite, game, x, y);
 	}
 
 	/**
@@ -107,6 +100,5 @@ public abstract class Actor extends Entity {
 	 * Destroys the actor by removing it from the Entity-Manager
 	 */
 	public abstract void destroy();
-	
 
 }

--- a/src/com/espen/src/Animation.java
+++ b/src/com/espen/src/Animation.java
@@ -15,25 +15,18 @@ public class Animation extends Entity {
 	/**
 	 * Constructor
 	 * 
-	 * @param image
+	 * @param sprite
 	 *            Spritesheet for this animation
 	 * @param game
 	 *            A reference to a game-object to get access to the other
 	 *            subsystems
-	 * @param cols
-	 *            number of columns the animation takes in the spritesheet
-	 * @param rows
-	 *            number of rows the animation takes in the spritesheet
-	 * @param animationSpeed
-	 *            how many ticks between the animation jumps to the next
-	 *            subimage
 	 * @param x
 	 *            x-coordinate of desired spawn-point
 	 * @param y
 	 *            y-coordinate of desired spawn-point
 	 */
-	public Animation(BufferedImage image, Game game, int cols, int rows, int animationSpeed, double x, double y) {
-		super(image, game, cols, rows, animationSpeed, x, y);
+	public Animation(BufferedImage[] sprite, Game game, double x, double y) {
+		super(sprite, game, x, y);
 		this.loopingAnimation = false;
 	}
 

--- a/src/com/espen/src/Blackboard.java
+++ b/src/com/espen/src/Blackboard.java
@@ -62,19 +62,7 @@ public class Blackboard {
 													// player's LVL3 laser
 
 	// Animations
-	public static final int EXPLOSION01SPEED = 5; // Animationspeed for the
-													// explosion01 animation
-	public static final int BLUEMUZZLEFLASHSPEED = 5; // Animationspeed for the
-														// blue muzzleflash
-														// animation
-	public static final int REDMUZZLEFLASHSPEED = 5; // Animationspeed for the
-														// red muzzleflash
-														// animation
-	public static final int BLUELASERIMPACTSPEED = 5; // Animationspeed for the
-														// blue laser impact
-														// animation
-	public static final int REDLASERIMPACTSPEED = 5; // Animationspeed for the
-														// red laser impact
-														// animation
-	
+	public static final int STANDARTANIMATIONSPEED = 5; // standart animation
+														// speed
+
 }

--- a/src/com/espen/src/BufferedImageLoader.java
+++ b/src/com/espen/src/BufferedImageLoader.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 import javax.imageio.ImageIO;
 
 /**
- * utility-class for loading images
+ * utility-class for loading images and spritesheets
  * 
  * @author Dennis
  *
@@ -14,6 +14,8 @@ import javax.imageio.ImageIO;
 public class BufferedImageLoader {
 
 	private BufferedImage image;
+	private BufferedImage[] sprite;
+	private int count = 0;
 
 	/**
 	 * Loading an image from the hard-drive into the game
@@ -24,9 +26,32 @@ public class BufferedImageLoader {
 	 * @throws IOException
 	 */
 	public BufferedImage loadImage(String path) throws IOException {
-
 		image = ImageIO.read(getClass().getResource(path));
 		return image;
+	}
+
+	/**
+	 * Loading an image from the hard-drive into the game and splitting it into
+	 * subimages. Those are then put into BufferedImage-Arrays
+	 * 
+	 * @param path Path where the image is located
+	 * @param cols Columns of images in the spritesheet
+	 * @param rows Rows of images in the spritesheet
+	 * @return BufferedImage[] holding all the subimages of the spritesheet
+	 * @throws IOException
+	 */
+	public BufferedImage[] loadSprite(String path, int cols, int rows, int subImageWidth, int subImageHeight) throws IOException {
+		sprite = new BufferedImage[cols * rows];
+		image = ImageIO.read(getClass().getResource(path));
+		// Fill the BufferedImage Array for the animation with subimages from
+		// the spritesheet
+		for (int i = 1; i <= rows; i++)
+			for (int j = 1; j <= cols; j++) {
+				sprite[count] = image.getSubimage((j * subImageWidth) - subImageWidth, (i * subImageHeight) - subImageHeight, subImageWidth, subImageHeight);
+				count++;
+			}
+		count = 0;
+		return sprite;
 	}
 
 }

--- a/src/com/espen/src/Enemy.java
+++ b/src/com/espen/src/Enemy.java
@@ -19,25 +19,18 @@ public class Enemy extends Actor {
 	/**
 	 * Constructor
 	 * 
-	 * @param image
+	 * @param sprite
 	 *            Spritesheet for this character
 	 * @param game
 	 *            A reference to a game-object to get access to the other
 	 *            subsystems
-	 * @param cols
-	 *            number of columns the animation takes in the spritesheet
-	 * @param rows
-	 *            number of rows the animation takes in the spritesheet
-	 * @param animationSpeed
-	 *            how many ticks between the animation jumps to the next
-	 *            subimage
 	 * @param x
 	 *            x-coordinate of desired spawn-point
 	 * @param y
 	 *            y-coordinate of desired spawn-point
 	 */
-	public Enemy(BufferedImage image, Game game, int cols, int rows, int animationSpeed, double x, double y) {
-		super(image, game, cols, rows, animationSpeed, x, y);
+	public Enemy(BufferedImage[] sprite, Game game, double x, double y) {
+		super(sprite, game, x, y);
 		velY = Blackboard.ENEMYSPEEDLVL1; // Player moves downwards after beeing
 											// spawned
 		random = new Random(); // Random-Class for randomizing shooting in the
@@ -93,10 +86,11 @@ public class Enemy extends Actor {
 	 */
 	private void shooting() {
 		if (player == null) { // check if player is null
-			player = game.getEntityManager().getPlayer(); // set the player. This
-														// prevents randomly
-														// happening
-														// null-pointer-exceptions
+			player = game.getEntityManager().getPlayer(); // set the player.
+															// This
+															// prevents randomly
+															// happening
+															// null-pointer-exceptions
 		}
 		count++; // increment null every tick
 		if (count > (Blackboard.TICKRATE / Blackboard.ENEMYFIRERATELVL1)) {// if

--- a/src/com/espen/src/EnemyLaser.java
+++ b/src/com/espen/src/EnemyLaser.java
@@ -15,25 +15,18 @@ public class EnemyLaser extends PlayerLaser {
 	/**
 	 * Constructor
 	 * 
-	 * @param image
+	 * @param sprite
 	 *            Spritesheet for this character
 	 * @param game
 	 *            A reference to a game-object to get access to the other
 	 *            subsystems
-	 * @param cols
-	 *            number of columns the animation takes in the spritesheet
-	 * @param rows
-	 *            number of rows the animation takes in the spritesheet
-	 * @param animationSpeed
-	 *            how many ticks between the animation jumps to the next
-	 *            subimage
 	 * @param x
 	 *            x-coordinate of desired spawn-point
 	 * @param y
 	 *            y-coordinate of desired spawn-point
 	 */
-	public EnemyLaser(BufferedImage image, Game game, int cols, int rows, int animationSpeed, double x, double y) {
-		super(image, game, cols, rows, animationSpeed, x, y);
+	public EnemyLaser(BufferedImage[] sprite, Game game, double x, double y) {
+		super(sprite, game, x, y);
 		speed = -Blackboard.SPEEDENEMYLASERLVL1; // set speed
 		damage = Blackboard.DAMAGEENEMYLASERLVL1; // set damage
 
@@ -46,9 +39,9 @@ public class EnemyLaser extends PlayerLaser {
 
 		if (player == null) { // check if player is null
 			player = game.getEntityManager().getPlayer();// set the player. This
-														// prevents randomly
-														// happening
-														// null-pointer-exceptions
+															// prevents randomly
+															// happening
+															// null-pointer-exceptions
 		}
 		collision = this.getBounds().intersects(player.getBounds()); // check if
 																		// the

--- a/src/com/espen/src/Entity.java
+++ b/src/com/espen/src/Entity.java
@@ -22,51 +22,33 @@ public abstract class Entity {
 	protected double velY;
 	protected double imageSize;
 	protected int tickcount = 0;
-	protected int animationIndex = 0;
+	protected int currentFrameOfAnimation = 0;
 	protected Game game;
 	protected Controller controller = null;
 
 	protected Textures textures;
 	protected BufferedImage[] sprite;
 	protected boolean loopingAnimation = true;
-	private int count = 0;
-	private int count2 = 0;
 
 	/**
 	 * Constructor
 	 * 
-	 * @param image
-	 *            Spritesheet for this character
+	 * @param sprite
+	 *            Spritesheet for this entity
 	 * @param game
 	 *            A reference to a game-object to get access to the other
 	 *            subsystems
-	 * @param cols
-	 *            number of columns the animation takes in the spritesheet
-	 * @param rows
-	 *            number of rows the animation takes in the spritesheet
-	 * @param animationSpeed
-	 *            how many ticks between the animation jumps to the next
-	 *            subimage
 	 * @param x
 	 *            x-coordinate of desired spawn-point
 	 * @param y
 	 *            y-coordinate of desired spawn-point
 	 */
-	public Entity(BufferedImage image, Game game, int cols, int rows, int animationSpeed, double x, double y) {
-		this.animationSpeed = animationSpeed;
-		this.count = cols * rows;
+	public Entity(BufferedImage[] sprite, Game game, double x, double y) {
+		this.animationSpeed = Blackboard.STANDARTANIMATIONSPEED;
 		this.game = game;
-		sprite = new BufferedImage[count];
+		this.sprite = sprite;
 		this.x = x;
 		this.y = y;
-		// Fill the BufferedImage Array for the animation with subimages from
-		// the spritesheet
-		for (int i = 1; i <= rows; i++)
-			for (int j = 1; j <= cols; j++) {
-				sprite[count2] = image.getSubimage((j * 32) - 32, (i * 32) - 32, 32, 32);
-				count2++;
-			}
-
 	}
 
 	/**
@@ -109,20 +91,22 @@ public abstract class Entity {
 	 * the tick-method handles all updates for the entity
 	 */
 	public void tick() {
-		x += velX;	//update the x-position with the x-velocity
-		y += velY;	//update the y-position with the y-velocity
+		x += velX; // update the x-position with the x-velocity
+		y += velY; // update the y-position with the y-velocity
 		tickcount++; // increment tickcount
 		if (tickcount >= animationSpeed) { // if tickcount reaches the desired
+											// amount
 											// of ticks between
 											// animationupdates...
-			animationIndex++; // ...increment the animation index
+			currentFrameOfAnimation++; // ...switch to the next frame
 			tickcount = 0; // reset tickcount
 		}
-		if (animationIndex >= sprite.length) {// if the animationIndex exceeds
-												// the size of the BufferedImage
-												// Array holding the sprites...
+		if (currentFrameOfAnimation >= sprite.length) {// if the frameindex
+														// exceeds
+			// the size of the BufferedImage
+			// Array holding the sprites...
 			if (loopingAnimation) { // ...and if the animation i set to loop...
-				animationIndex = 0; // ...reset the index
+				currentFrameOfAnimation = 0; // ...reset the index
 				// else-case is used for the animation-class
 			} else { // if the animation is not set to loop
 				destroy(); // destroy the entity
@@ -139,9 +123,10 @@ public abstract class Entity {
 	 */
 	public void render(Graphics g) {
 
-		g.drawImage(sprite[animationIndex], (int) x, (int) y, null); // draw the
-																		// current
-																		// sprite
+		g.drawImage(sprite[currentFrameOfAnimation], (int) x, (int) y, null); // draw
+																				// the
+		// current
+		// sprite
 
 	}
 

--- a/src/com/espen/src/Player.java
+++ b/src/com/espen/src/Player.java
@@ -22,20 +22,13 @@ public class Player extends Actor {
 	 * @param game
 	 *            A reference to a game-object to get access to the other
 	 *            subsystems
-	 * @param cols
-	 *            number of columns the animation takes in the spritesheet
-	 * @param rows
-	 *            number of rows the animation takes in the spritesheet
-	 * @param animationSpeed
-	 *            how many ticks between the animation jumps to the next
-	 *            subimage
 	 * @param x
 	 *            x-coordinate of desired spawn-point
 	 * @param y
 	 *            y-coordinate of desired spawn-point
 	 */
-	public Player(Game game, int cols, int rows, int animationSpeed, double x, double y) {
-		super(game.getTextures().getPlayer(), game, cols, rows, animationSpeed, x, y);
+	public Player(Game game, double x, double y) {
+		super(game.getTextures().getPlayer(), game, x, y);
 		this.setLevel(1); // set starting-level
 		health = 100; // set hitpoints
 		controller = game.getController(); // set controller
@@ -246,9 +239,10 @@ public class Player extends Actor {
 	}
 
 	/**
-	 * this method must be implemented when extending actor. There is no use in the
-	 * playerclass for this method because the destruction of the player is handled in the
-	 * controller on GameOver. So the body of this method is empty.
+	 * this method must be implemented when extending actor. There is no use in
+	 * the playerclass for this method because the destruction of the player is
+	 * handled in the controller on GameOver. So the body of this method is
+	 * empty.
 	 */
 	public void destroy() {
 

--- a/src/com/espen/src/PlayerController.java
+++ b/src/com/espen/src/PlayerController.java
@@ -59,6 +59,7 @@ public class PlayerController {
 	 * handles the keyPressed events
 	 * 
 	 * @param e
+	 *            KeyEvent
 	 */
 	public void keyPressed(KeyEvent e) {
 		int key = e.getKeyCode();
@@ -89,6 +90,7 @@ public class PlayerController {
 	 * handles the keyReleased events
 	 * 
 	 * @param e
+	 *            KeyEvent
 	 */
 	public void keyReleased(KeyEvent e) {
 		int key = e.getKeyCode();

--- a/src/com/espen/src/PlayerLaser.java
+++ b/src/com/espen/src/PlayerLaser.java
@@ -24,25 +24,18 @@ public class PlayerLaser extends Entity implements Projectile {
 	/**
 	 * Constructor
 	 * 
-	 * @param image
-	 *            Spritesheet for this character
+	 * @param sprite
+	 *            Spritesheet for this Entity
 	 * @param game
 	 *            A reference to a game-object to get access to the other
 	 *            subsystems
-	 * @param cols
-	 *            number of columns the animation takes in the spritesheet
-	 * @param rows
-	 *            number of rows the animation takes in the spritesheet
-	 * @param animationSpeed
-	 *            how many ticks between the animation jumps to the next
-	 *            subimage
 	 * @param x
 	 *            x-coordinate of desired spawn-point
 	 * @param y
 	 *            y-coordinate of desired spawn-point
 	 */
-	public PlayerLaser(BufferedImage image, Game game, int cols, int rows, int animationSpeed, double x, double y) {
-		super(image, game, cols, rows, animationSpeed, x, y);
+	public PlayerLaser(BufferedImage[] sprite, Game game, double x, double y) {
+		super(sprite, game, x, y);
 		damage = Blackboard.DAMAGELASSERLVL1; // set damage
 		speed = Blackboard.SPEEDLASERLVL1; // set speed
 	}

--- a/src/com/espen/src/SpawnSystem.java
+++ b/src/com/espen/src/SpawnSystem.java
@@ -2,130 +2,199 @@ package com.espen.src;
 
 /**
  * Class responsible for spawning entities into the game
+ * 
  * @author Dennis
  *
  */
 public class SpawnSystem {
-	
+
 	Game game;
 	Player player;
 	private int xOffsetLaserLVL1 = Blackboard.XOFFSETLASERLVL1;
 	private int xOffsetLaserLVL2 = Blackboard.XOFFSETLASERLVL2;
 	private int xOffsetLaserLVL3 = Blackboard.XOFFSETLASERLVL3;
+
 	/**
 	 * Constructor
-	 * @param game reference to game to access the other subsystems
+	 * 
+	 * @param game
+	 *            reference to game to access the other subsystems
 	 */
-	public SpawnSystem(Game game){
+	public SpawnSystem(Game game) {
 		this.game = game;
 	}
+
 	/**
 	 * Spawn the player
-	 * @param x desired x-position
-	 * @param y desired y-position
+	 * 
+	 * @param x
+	 *            desired x-position
+	 * @param y
+	 *            desired y-position
 	 */
-	public void spawnPlayer(double x, double y){
-		game.getEntityManager().setPlayer(new Player(game, 2, 1, 5, 200, 200));
+	public void spawnPlayer(double x, double y) {
+		game.getEntityManager().setPlayer(new Player(game, 200, 200));
 	}
+
 	/**
 	 * spawn a projectile for a player laser LVL1
-	 * @param x desired x-position
-	 * @param y desired y-position
+	 * 
+	 * @param x
+	 *            desired x-position
+	 * @param y
+	 *            desired y-position
 	 */
 	public void spawnPlayerLaserLVL1(double x, double y) {
 		xOffsetLaserLVL1 = -xOffsetLaserLVL1; // swap x-Offset
-		PlayerLaser temp = new PlayerLaser(game.getTextures().getLaser(), game,1,1,5,x + xOffsetLaserLVL1,y); //Instantiate a temporary Projectile
-		temp.setDamage(Blackboard.DAMAGELASSERLVL1);//set the damage
-		temp.setSpeed(Blackboard.SPEEDLASERLVL1);//set the speed
-		game.getEntityManager().getProjectiles().add(temp);//spawn the projectile
-		game.getSpawnSystem().spawnBlueMuzzleFlash(x + xOffsetLaserLVL1, y - 15);//spawn a muzzleflash
+		PlayerLaser temp = new PlayerLaser(game.getTextures().getLaser(), game, x + xOffsetLaserLVL1, y); // Instantiate
+																											// a
+																											// temporary
+																											// Projectile
+		temp.setDamage(Blackboard.DAMAGELASSERLVL1);// set the damage
+		temp.setSpeed(Blackboard.SPEEDLASERLVL1);// set the speed
+		game.getEntityManager().getProjectiles().add(temp);// spawn the
+															// projectile
+		game.getSpawnSystem().spawnBlueMuzzleFlash(x + xOffsetLaserLVL1, y - 15);// spawn
+																					// a
+																					// muzzleflash
 
 	}
+
 	/**
 	 * spawn a projectile for a player laser LVL2
-	 * @param x desired x-position
-	 * @param y desired y-position
+	 * 
+	 * @param x
+	 *            desired x-position
+	 * @param y
+	 *            desired y-position
 	 */
 	public void spawnPlayerLaserLVL2(double x, double y) {
 		xOffsetLaserLVL2 = -xOffsetLaserLVL2; // swap x-Offset
-		PlayerLaser temp = new PlayerLaser(game.getTextures().getLaser(), game,1,1,5,x + xOffsetLaserLVL2,y); //Instantiate a temporary Projectile
-		temp.setDamage(Blackboard.DAMAGELASERLVL2); //set the damage
-		temp.setSpeed(Blackboard.SPEEDLASERLVL2); //set the speed
-		game.getEntityManager().getProjectiles().add(temp); //spawn the projectile
-		game.getSpawnSystem().spawnBlueMuzzleFlash(x + xOffsetLaserLVL2, y - 15); //spawn a muzzleflash
+		PlayerLaser temp = new PlayerLaser(game.getTextures().getLaser(), game, x + xOffsetLaserLVL2, y); // Instantiate
+																											// a
+																											// temporary
+																											// Projectile
+		temp.setDamage(Blackboard.DAMAGELASERLVL2); // set the damage
+		temp.setSpeed(Blackboard.SPEEDLASERLVL2); // set the speed
+		game.getEntityManager().getProjectiles().add(temp); // spawn the
+															// projectile
+		game.getSpawnSystem().spawnBlueMuzzleFlash(x + xOffsetLaserLVL2, y - 15); // spawn
+																					// a
+																					// muzzleflash
 	}
+
 	/**
 	 * spawn a projectile for a player laser LVL3
-	 * @param x desired x-position
-	 * @param y desired y-position
+	 * 
+	 * @param x
+	 *            desired x-position
+	 * @param y
+	 *            desired y-position
 	 */
 	public void spawnPlayerLaserLVL3(double x, double y) {
 		xOffsetLaserLVL3 = -xOffsetLaserLVL3; // swap x-Offset
-		PlayerLaser temp = new PlayerLaser(game.getTextures().getLaser(), game,1,1,5,x + xOffsetLaserLVL3,y + 15); //Instantiate a temporary Projectile
-		temp.setDamage(Blackboard.DAMAGELASERLVL3);//set the damage
-		temp.setSpeed(Blackboard.SPEEDLASERLVL3);//set the speed
-		game.getEntityManager().getProjectiles().add(temp);//spawn the projectile
-		game.getSpawnSystem().spawnBlueMuzzleFlash(x + xOffsetLaserLVL3, y);//spawn a muzzleflash
-		
+		PlayerLaser temp = new PlayerLaser(game.getTextures().getLaser(), game, x + xOffsetLaserLVL3, y + 15); // Instantiate
+																												// a
+																												// temporary
+																												// Projectile
+		temp.setDamage(Blackboard.DAMAGELASERLVL3);// set the damage
+		temp.setSpeed(Blackboard.SPEEDLASERLVL3);// set the speed
+		game.getEntityManager().getProjectiles().add(temp);// spawn the
+															// projectile
+		game.getSpawnSystem().spawnBlueMuzzleFlash(x + xOffsetLaserLVL3, y);// spawn
+																			// a
+																			// muzzleflash
+
 	}
+
 	/**
 	 * spawn a projectile for an enemy laser LVL1
-	 * @param x desired x-position
-	 * @param y desired y-position
+	 * 
+	 * @param x
+	 *            desired x-position
+	 * @param y
+	 *            desired y-position
 	 */
 	public void spawnEnemyLaserLVL1(double x, double y) {
-		game.getEntityManager().getProjectiles().add(new EnemyLaser(game.getTextures().getEnemyLaser(), game,1,1,5,x,y+20)); //spawn projectile
-		game.getSpawnSystem().spawnRedMuzzleFlash(x, y);//spawn a muzzleflash
+		game.getEntityManager().getProjectiles()
+				.add(new EnemyLaser(game.getTextures().getEnemyLaser(), game, x, y + 20)); // spawn
+																							// projectile
+		game.getSpawnSystem().spawnRedMuzzleFlash(x, y);// spawn a muzzleflash
 	}
+
 	/**
 	 * spawn an explosion01 animation
-	 * @param x desired x-position
-	 * @param y desired y-position
+	 * 
+	 * @param x
+	 *            desired x-position
+	 * @param y
+	 *            desired y-position
 	 */
 	public void spawnExplosion01(double x, double y) {
-		game.getEntityManager().getAnimations().add(new Animation(game.getTextures().getExplosion01(), game, 4, 4, Blackboard.EXPLOSION01SPEED, x, y)); //spawn animation
+		game.getEntityManager().getAnimations().add(new Animation(game.getTextures().getExplosion01(), game, x, y)); // spawn
+																														// animation
 	}
+
 	/**
 	 * spawn an blue muzzleflash animation
-	 * @param x desired x-position
-	 * @param y desired y-position
+	 * 
+	 * @param x
+	 *            desired x-position
+	 * @param y
+	 *            desired y-position
 	 */
 	public void spawnBlueMuzzleFlash(double x, double y) {
-		game.getEntityManager().getAnimations().add(new Animation(game.getTextures().getBlueMuzzleFlash(), game, 4, 1, Blackboard.BLUEMUZZLEFLASHSPEED, x, y)); //spawn animation
+		game.getEntityManager().getAnimations().add(new Animation(game.getTextures().getBlueMuzzleFlash(), game, x, y)); // spawn
+																															// animation
 	}
+
 	/**
 	 * spawn an red muzzleflash animation
-	 * @param x desired x-position
-	 * @param y desired y-position
+	 * 
+	 * @param x
+	 *            desired x-position
+	 * @param y
+	 *            desired y-position
 	 */
 	public void spawnRedMuzzleFlash(double x, double y) {
-		game.getEntityManager().getAnimations().add(new Animation(game.getTextures().getRedMuzzleFlash(), game, 4, 1, Blackboard.REDMUZZLEFLASHSPEED, x, y)); //spawn animation
+		game.getEntityManager().getAnimations().add(new Animation(game.getTextures().getRedMuzzleFlash(), game, x, y)); // spawn
+																														// animation
 	}
+
 	/**
 	 * spawn an blue laserimpact animation
-	 * @param x desired x-position
-	 * @param y desired y-position
+	 * 
+	 * @param x
+	 *            desired x-position
+	 * @param y
+	 *            desired y-position
 	 */
-	public void spawnBlueLaserImpact(double x, double y){
-		game.getEntityManager().getAnimations().add(new Animation(game.getTextures().getBlueLaserImpact(), game, 2, 2, Blackboard.BLUELASERIMPACTSPEED, x, y)); //spawn animation
+	public void spawnBlueLaserImpact(double x, double y) {
+		game.getEntityManager().getAnimations().add(new Animation(game.getTextures().getBlueLaserImpact(), game, x, y)); // spawn
+																															// animation
 	}
+
 	/**
 	 * spawn an red laserimpact animation
-	 * @param x desired x-position
-	 * @param y desired y-position
+	 * 
+	 * @param x
+	 *            desired x-position
+	 * @param y
+	 *            desired y-position
 	 */
-	public void spawnRedLaserImpact(double x, double y){
-		game.getEntityManager().getAnimations().add(new Animation(game.getTextures().getRedLaserImpact(), game, 2, 2, Blackboard.REDLASERIMPACTSPEED, x, y)); //spawn animation
+	public void spawnRedLaserImpact(double x, double y) {
+		game.getEntityManager().getAnimations().add(new Animation(game.getTextures().getRedLaserImpact(), game, x, y)); // spawn
+																														// animation
 	}
+
 	/**
 	 * spawn an enemy wave
 	 */
 	public void spawnWave() {
 		for (int x = 0; x < (Blackboard.GAMEWIDTH); x += 64) {
-			game.getEntityManager().getEnemies().add(new Enemy(game.getTextures().getEnemy(),game,2,1,5,x,0)); //spawn enemy
+			game.getEntityManager().getEnemies().add(new Enemy(game.getTextures().getEnemy(), game, x, 0)); // spawn
+																											// enemy
 		}
 	}
-
-
 
 }

--- a/src/com/espen/src/Textures.java
+++ b/src/com/espen/src/Textures.java
@@ -10,17 +10,17 @@ import java.io.IOException;
  *
  */
 public class Textures {
-	private BufferedImage image;
 	private BufferedImage background;
-	private BufferedImage explosion01;
-	private BufferedImage blueMuzzleFlash;
-	private BufferedImage redMuzzleFlash;
-	private BufferedImage player;
-	private BufferedImage enemy;
-	private BufferedImage laser;
-	private BufferedImage enemyLaser;
-	private BufferedImage blueLaserImpact;
-	private BufferedImage redLaserImpact;
+	private BufferedImage image;
+	private BufferedImage[] explosion01;
+	private BufferedImage[] blueMuzzleFlash;
+	private BufferedImage[] redMuzzleFlash;
+	private BufferedImage[] player;
+	private BufferedImage[] enemy;
+	private BufferedImage[] laser;
+	private BufferedImage[] enemyLaser;
+	private BufferedImage[] blueLaserImpact;
+	private BufferedImage[] redLaserImpact;
 
 	/**
 	 * Constructor
@@ -47,22 +47,22 @@ public class Textures {
 																												// buffer
 			background = loader.loadImage("/background.png"); // background
 																// image
-			explosion01 = loader.loadImage("/explosion01.png");
-			blueMuzzleFlash = loader.loadImage("/blue_muzzle_flash.png");
-			redMuzzleFlash = loader.loadImage("/red_muzzle_flash.png");
-			player = loader.loadImage("/player.png");
-			enemy = loader.loadImage("/enemy.png");
-			laser = loader.loadImage("/laser.png");
-			enemyLaser = loader.loadImage("/enemyLaser.png");
-			blueLaserImpact = loader.loadImage("/blue_laser_impact.png");
-			redLaserImpact = loader.loadImage("/red_laser_impact.png");
+			explosion01 = loader.loadSprite("/explosion01.png", 4, 4, 32, 32);
+			blueMuzzleFlash = loader.loadSprite("/blue_muzzle_flash.png", 4, 1, 32, 32);
+			redMuzzleFlash = loader.loadSprite("/red_muzzle_flash.png", 4, 1, 32, 32);
+			player = loader.loadSprite("/player.png", 2, 1, 32, 32);
+			enemy = loader.loadSprite("/enemy.png", 2, 1, 32, 32);
+			laser = loader.loadSprite("/laser.png", 1, 1, 32, 32);
+			enemyLaser = loader.loadSprite("/enemyLaser.png", 1, 1, 32, 32);
+			blueLaserImpact = loader.loadSprite("/blue_laser_impact.png", 2, 2, 32, 32);
+			redLaserImpact = loader.loadSprite("/red_laser_impact.png", 2, 2, 32, 32);
 
 		} catch (IOException e) {
 			e.printStackTrace();
 		}
 	}
 
-	// Getters for all the images
+	// Getters for all the images and sprites
 
 	public BufferedImage getImage() {
 		return image;
@@ -72,39 +72,39 @@ public class Textures {
 		return background;
 	}
 
-	public BufferedImage getExplosion01() {
+	public BufferedImage[] getExplosion01() {
 		return explosion01;
 	}
 
-	public BufferedImage getBlueMuzzleFlash() {
+	public BufferedImage[] getBlueMuzzleFlash() {
 		return blueMuzzleFlash;
 	}
 
-	public BufferedImage getRedMuzzleFlash() {
+	public BufferedImage[] getRedMuzzleFlash() {
 		return redMuzzleFlash;
 	}
 
-	public BufferedImage getPlayer() {
+	public BufferedImage[] getPlayer() {
 		return player;
 	}
 
-	public BufferedImage getEnemy() {
+	public BufferedImage[] getEnemy() {
 		return enemy;
 	}
 
-	public BufferedImage getLaser() {
+	public BufferedImage[] getLaser() {
 		return laser;
 	}
 
-	public BufferedImage getEnemyLaser() {
+	public BufferedImage[] getEnemyLaser() {
 		return enemyLaser;
 	}
 
-	public BufferedImage getBlueLaserImpact() {
+	public BufferedImage[] getBlueLaserImpact() {
 		return blueLaserImpact;
 	}
 
-	public BufferedImage getRedLaserImpact() {
+	public BufferedImage[] getRedLaserImpact() {
 		return redLaserImpact;
 	}
 }


### PR DESCRIPTION
The Splitting of the Spritesheets into BufferedImageArrays was moved
from the entity-class's constructor into the BufferedImageLoader. The
BufferedImageLoader now has added utility which also better fits into
this class instead of the entity-class. The new methods are called by
the Textures-class. The needed parameters can be set in this class and
the resulting BufferedImageArrays are now stored in it. Not only is it
cleaner to handle and store the textures in the Textures class, now
there is only one Array per Spritesheet stored instead of one per
entity. The Entities now only get references to these Arrays.
